### PR TITLE
Añadir enlace al bot de telegram ComedoresUGRbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,11 @@ title: Inicio
                 <span class="icon has-text-dark"><i class="fa fa-shopping-bag"></i></span>
               </a>
             </p>
+            <p class="control">
+ +            <a class="button" href="http://telegram.me/ComedoresUGRbot" title="Menú en Telegram">
+ +              <span class="icon has-text-dark"><i class="fa fa-telegram"></i></span>
+ +            </a>
+ +          </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
¡Hola!

Hace un tiempo desarrollé un bot de Telegram que permite consultar el menú de los comedores de la UGR de forma rápida, evitando así tener que visitar scu.ugr.es (el bot es más cómodo especialmente si usamos el móvil para consultar el menú).

He creado este pull request para añadir el enlace al mismo, ya que creo que puede resultarle útil a más gente.

Este es el resultado:

![image](https://user-images.githubusercontent.com/282431/32298493-bcba9930-bf52-11e7-8fad-1d9004f82eb5.png)